### PR TITLE
Add DelegatingDockerClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>1.609.1</jenkins.version>
         <java.level>8</java.level>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hpi.compatibleSinceVersion>3.1</hpi.compatibleSinceVersion>
     </properties>
 
@@ -125,6 +126,19 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
             <version>2.6.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/jenkins/dockerjavaapi/client/DelegatingDockerClient.java
+++ b/src/main/java/io/jenkins/dockerjavaapi/client/DelegatingDockerClient.java
@@ -1,0 +1,437 @@
+// Copyright 2011 Peter Darton
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package io.jenkins.dockerjavaapi.client;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.Nonnull;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.*;
+import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.model.*;
+
+// MAINTENANCE NOTE:
+// The DockerClient API varies depending on the version of the docker-java
+// library that this plugin provides.
+// It may be necessary to add/remove methods from this class when changing
+// the version of docker-java.
+// ...but, by having this here, it allows all other Jenkins plugins to be much
+// less affected by changes to the version of docker-java, meaning that this
+// plugin can be upgraded without breaking every other docker-using plugin.
+
+/**
+ * Simple delegate class for the {@link DockerClient} interface.
+ * <p>
+ * This makes it easy for other classes to override specific methods without
+ * having to implement all of them.
+ * </p>
+ * If you are writing a Jenkins plugin that needs a class to implement/wrap
+ * {@link DockerClient}, you'd be best advised to extend this one, otherwise
+ * your code could fail whenever the version of this plugin changes.
+ */
+@SuppressWarnings("deprecation")
+public class DelegatingDockerClient implements DockerClient {
+
+    private final DockerClient delegate;
+
+    /**
+     * Constructs a new instance that delegates all API calls to the specified
+     * {@link DockerClient}.
+     *
+     * @param delegate The {@link DockerClient} to delegate to.
+     */
+    public DelegatingDockerClient(@Nonnull DockerClient delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Obtains the underlying {@link DockerClient} interface. Subclasses can
+     * override this if they need to hook into every call.
+     *
+     * @return the {@link DockerClient} to be delegated to.
+     */
+    @Nonnull
+    protected DockerClient getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public AttachContainerCmd attachContainerCmd(String arg0) {
+        return getDelegate().attachContainerCmd(arg0);
+    }
+
+    @Override
+    public AuthCmd authCmd() {
+        return getDelegate().authCmd();
+    }
+
+    @Override
+    public AuthConfig authConfig() throws DockerException {
+        return getDelegate().authConfig();
+    }
+
+    @Override
+    public BuildImageCmd buildImageCmd() {
+        return getDelegate().buildImageCmd();
+    }
+
+    @Override
+    public BuildImageCmd buildImageCmd(File arg0) {
+        return getDelegate().buildImageCmd(arg0);
+    }
+
+    @Override
+    public BuildImageCmd buildImageCmd(InputStream arg0) {
+        return getDelegate().buildImageCmd(arg0);
+    }
+
+    @Override
+    public void close() throws IOException {
+        getDelegate().close();
+    }
+
+    @Override
+    public CommitCmd commitCmd(String arg0) {
+        return getDelegate().commitCmd(arg0);
+    }
+
+    @Override
+    public ConnectToNetworkCmd connectToNetworkCmd() {
+        return getDelegate().connectToNetworkCmd();
+    }
+
+    @Override
+    public ContainerDiffCmd containerDiffCmd(String arg0) {
+        return getDelegate().containerDiffCmd(arg0);
+    }
+
+    @Override
+    public CopyArchiveFromContainerCmd copyArchiveFromContainerCmd(String arg0, String arg1) {
+        return getDelegate().copyArchiveFromContainerCmd(arg0, arg1);
+    }
+
+    @Override
+    public CopyArchiveToContainerCmd copyArchiveToContainerCmd(String arg0) {
+        return getDelegate().copyArchiveToContainerCmd(arg0);
+    }
+
+    @Override
+    public CopyFileFromContainerCmd copyFileFromContainerCmd(String arg0, String arg1) {
+        return getDelegate().copyFileFromContainerCmd(arg0, arg1);
+    }
+
+    @Override
+    public CreateContainerCmd createContainerCmd(String arg0) {
+        return getDelegate().createContainerCmd(arg0);
+    }
+
+    @Override
+    public CreateImageCmd createImageCmd(String arg0, InputStream arg1) {
+        return getDelegate().createImageCmd(arg0, arg1);
+    }
+
+    @Override
+    public CreateNetworkCmd createNetworkCmd() {
+        return getDelegate().createNetworkCmd();
+    }
+
+    @Override
+    public CreateVolumeCmd createVolumeCmd() {
+        return getDelegate().createVolumeCmd();
+    }
+
+    @Override
+    public DisconnectFromNetworkCmd disconnectFromNetworkCmd() {
+        return getDelegate().disconnectFromNetworkCmd();
+    }
+
+    @Override
+    public EventsCmd eventsCmd() {
+        return getDelegate().eventsCmd();
+    }
+
+    @Override
+    public ExecCreateCmd execCreateCmd(String arg0) {
+        return getDelegate().execCreateCmd(arg0);
+    }
+
+    @Override
+    public ExecStartCmd execStartCmd(String arg0) {
+        return getDelegate().execStartCmd(arg0);
+    }
+
+    @Override
+    public InfoCmd infoCmd() {
+        return getDelegate().infoCmd();
+    }
+
+    @Override
+    public InspectContainerCmd inspectContainerCmd(String arg0) {
+        return getDelegate().inspectContainerCmd(arg0);
+    }
+
+    @Override
+    public InspectExecCmd inspectExecCmd(String arg0) {
+        return getDelegate().inspectExecCmd(arg0);
+    }
+
+    @Override
+    public InspectImageCmd inspectImageCmd(String arg0) {
+        return getDelegate().inspectImageCmd(arg0);
+    }
+
+    @Override
+    public InspectNetworkCmd inspectNetworkCmd() {
+        return getDelegate().inspectNetworkCmd();
+    }
+
+    @Override
+    public InspectVolumeCmd inspectVolumeCmd(String arg0) {
+        return getDelegate().inspectVolumeCmd(arg0);
+    }
+
+    @Override
+    public KillContainerCmd killContainerCmd(String arg0) {
+        return getDelegate().killContainerCmd(arg0);
+    }
+
+    @Override
+    public ListContainersCmd listContainersCmd() {
+        return getDelegate().listContainersCmd();
+    }
+
+    @Override
+    public ListImagesCmd listImagesCmd() {
+        return getDelegate().listImagesCmd();
+    }
+
+    @Override
+    public ListNetworksCmd listNetworksCmd() {
+        return getDelegate().listNetworksCmd();
+    }
+
+    @Override
+    public ListVolumesCmd listVolumesCmd() {
+        return getDelegate().listVolumesCmd();
+    }
+
+    @Override
+    public LoadImageCmd loadImageCmd(InputStream arg0) {
+        return getDelegate().loadImageCmd(arg0);
+    }
+
+    @Override
+    public LogContainerCmd logContainerCmd(String arg0) {
+        return getDelegate().logContainerCmd(arg0);
+    }
+
+    @Override
+    public PauseContainerCmd pauseContainerCmd(String arg0) {
+        return getDelegate().pauseContainerCmd(arg0);
+    }
+
+    @Override
+    public PingCmd pingCmd() {
+        return getDelegate().pingCmd();
+    }
+
+    @Override
+    public PullImageCmd pullImageCmd(String arg0) {
+        return getDelegate().pullImageCmd(arg0);
+    }
+
+    @Override
+    public PushImageCmd pushImageCmd(String arg0) {
+        return getDelegate().pushImageCmd(arg0);
+    }
+
+    @Override
+    public PushImageCmd pushImageCmd(Identifier arg0) {
+        return getDelegate().pushImageCmd(arg0);
+    }
+
+    @Override
+    public RemoveContainerCmd removeContainerCmd(String arg0) {
+        return getDelegate().removeContainerCmd(arg0);
+    }
+
+    @Override
+    public RemoveImageCmd removeImageCmd(String arg0) {
+        return getDelegate().removeImageCmd(arg0);
+    }
+
+    @Override
+    public RemoveNetworkCmd removeNetworkCmd(String arg0) {
+        return getDelegate().removeNetworkCmd(arg0);
+    }
+
+    @Override
+    public RemoveVolumeCmd removeVolumeCmd(String arg0) {
+        return getDelegate().removeVolumeCmd(arg0);
+    }
+
+    @Override
+    public RenameContainerCmd renameContainerCmd(String arg0) {
+        return getDelegate().renameContainerCmd(arg0);
+    }
+
+    @Override
+    public RestartContainerCmd restartContainerCmd(String arg0) {
+        return getDelegate().restartContainerCmd(arg0);
+    }
+
+    @Override
+    public SaveImageCmd saveImageCmd(String arg0) {
+        return getDelegate().saveImageCmd(arg0);
+    }
+
+    @Override
+    public SearchImagesCmd searchImagesCmd(String arg0) {
+        return getDelegate().searchImagesCmd(arg0);
+    }
+
+    @Override
+    public StartContainerCmd startContainerCmd(String arg0) {
+        return getDelegate().startContainerCmd(arg0);
+    }
+
+    @Override
+    public StatsCmd statsCmd(String arg0) {
+        return getDelegate().statsCmd(arg0);
+    }
+
+    @Override
+    public StopContainerCmd stopContainerCmd(String arg0) {
+        return getDelegate().stopContainerCmd(arg0);
+    }
+
+    @Override
+    public TagImageCmd tagImageCmd(String arg0, String arg1, String arg2) {
+        return getDelegate().tagImageCmd(arg0, arg1, arg2);
+    }
+
+    @Override
+    public TopContainerCmd topContainerCmd(String arg0) {
+        return getDelegate().topContainerCmd(arg0);
+    }
+
+    @Override
+    public UnpauseContainerCmd unpauseContainerCmd(String arg0) {
+        return getDelegate().unpauseContainerCmd(arg0);
+    }
+
+    @Override
+    public UpdateContainerCmd updateContainerCmd(String arg0) {
+        return getDelegate().updateContainerCmd(arg0);
+    }
+
+    @Override
+    public VersionCmd versionCmd() {
+        return getDelegate().versionCmd();
+    }
+
+    @Override
+    public WaitContainerCmd waitContainerCmd(String arg0) {
+        return getDelegate().waitContainerCmd(arg0);
+    }
+
+    @Override
+    public InitializeSwarmCmd initializeSwarmCmd(SwarmSpec swarmSpec) {
+        return getDelegate().initializeSwarmCmd(swarmSpec);
+    }
+
+    @Override
+    public InspectSwarmCmd inspectSwarmCmd() {
+        return getDelegate().inspectSwarmCmd();
+    }
+
+    @Override
+    public JoinSwarmCmd joinSwarmCmd() {
+        return getDelegate().joinSwarmCmd();
+    }
+
+    @Override
+    public LeaveSwarmCmd leaveSwarmCmd() {
+        return getDelegate().leaveSwarmCmd();
+    }
+
+    @Override
+    public UpdateSwarmCmd updateSwarmCmd(SwarmSpec swarmSpec) {
+        return getDelegate().updateSwarmCmd(swarmSpec);
+    }
+
+    @Override
+    public UpdateSwarmNodeCmd updateSwarmNodeCmd() {
+        return getDelegate().updateSwarmNodeCmd();
+    }
+
+    @Override
+    public ListSwarmNodesCmd listSwarmNodesCmd() {
+        return getDelegate().listSwarmNodesCmd();
+    }
+
+    @Override
+    public ListServicesCmd listServicesCmd() {
+        return getDelegate().listServicesCmd();
+    }
+
+    @Override
+    public CreateServiceCmd createServiceCmd(ServiceSpec serviceSpec) {
+        return getDelegate().createServiceCmd(serviceSpec);
+    }
+
+    @Override
+    public InspectServiceCmd inspectServiceCmd(String serviceId) {
+        return getDelegate().inspectServiceCmd(serviceId);
+    }
+
+    @Override
+    public UpdateServiceCmd updateServiceCmd(String serviceId, ServiceSpec serviceSpec) {
+        return getDelegate().updateServiceCmd(serviceId, serviceSpec);
+    }
+
+    @Override
+    public RemoveServiceCmd removeServiceCmd(String serviceId) {
+        return getDelegate().removeServiceCmd(serviceId);
+    }
+
+    @Override
+    public ListTasksCmd listTasksCmd() {
+        return getDelegate().listTasksCmd();
+    }
+
+    @Override
+    public LogSwarmObjectCmd logServiceCmd(String serviceId) {
+        return getDelegate().logServiceCmd(serviceId);
+    }
+
+    @Override
+    public LogSwarmObjectCmd logTaskCmd(String taskId) {
+        return getDelegate().logTaskCmd(taskId);
+    }
+
+    @Override
+    public PruneCmd pruneCmd(PruneType pruneType) {
+        return getDelegate().pruneCmd(pruneType);
+    }
+}

--- a/src/test/java/io/jenkins/dockerjavaapi/client/DelegatingDockerClientTest.java
+++ b/src/test/java/io/jenkins/dockerjavaapi/client/DelegatingDockerClientTest.java
@@ -1,0 +1,157 @@
+// Copyright 2011 Peter Darton
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+package io.jenkins.dockerjavaapi.client;
+
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.exceptions.base.MockitoException;
+
+import com.github.dockerjava.api.DockerClient;
+
+/**
+ * Ensures that every method in DelegatingDockerClient delegates to the matching
+ * method in the instance it delegates to. Uses reflection/introspection to
+ * ensure that this class doesn't need updating if new methods are added.
+ */
+@RunWith(Parameterized.class)
+public class DelegatingDockerClientTest {
+
+    /**
+     * Defines the set of data that all test methods (in this test class) will be
+     * run with - in this case, it's all the methods of {@link DockerClient}.
+     * <p>
+     * Each element in the returned {@link Iterable} is an Object[] whose contents
+     * matches the arguments taken by this class's constructor.
+     * </p>
+     * The annotation <code>name = "{0}"</code> says that the name of each set of
+     * data should be first element of the array.
+     * 
+     * @return {@link Iterable} of [ {@link String}, {@link Method} ].
+     */
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> data() {
+        final List<Object[]> data = new ArrayList<>();
+        final Method[] declaredMethods = DockerClient.class.getDeclaredMethods();
+        for (Method m : declaredMethods) {
+            final StringBuilder testCaseName = new StringBuilder(m.getName());
+            testCaseName.append('(');
+            for (Class<?> t : m.getParameterTypes()) {
+                final String tName = t.getSimpleName();
+                if (testCaseName.charAt(testCaseName.length() - 1) != '(') {
+                    testCaseName.append(',');
+                }
+                testCaseName.append(tName);
+            }
+            testCaseName.append(')');
+            final Object[] testCase = new Object[] { testCaseName.toString(), m };
+            data.add(testCase);
+        }
+        data.sort(new Comparator<Object[]>() {
+            @Override
+            public int compare(Object[] o1, Object[] o2) {
+                final String n1 = (String) o1[0];
+                final String n2 = (String) o2[0];
+                return n1.compareTo(n2);
+            }
+        });
+        return data;
+    }
+
+    private final String dockerClientMethodName;
+    private final Method dockerClientMethod;
+
+    public DelegatingDockerClientTest(String methodName, Method dockerClientMethod) {
+        this.dockerClientMethodName = methodName;
+        this.dockerClientMethod = dockerClientMethod;
+    }
+
+    @Test
+    public void methodIsDelegatedCorrectly() throws Exception {
+        // Given
+        final Parameter[] methodParameters = dockerClientMethod.getParameters();
+        final Object[] mockParameters = createFakeArgumentValues(methodParameters);
+        final Class<?> methodReturnType = dockerClientMethod.getReturnType();
+        final Object mockReturnValue = methodReturnType.equals(Void.TYPE) ? null
+                : createFakeObject(methodReturnType, dockerClientMethodName + "ReturnedValue");
+        final DockerClient mockDelegate = mock(DockerClient.class, "mockDelegate");
+        if (mockReturnValue != null) {
+            when(dockerClientMethod.invoke(mockDelegate, mockParameters)).thenReturn(mockReturnValue);
+        }
+        final DelegatingDockerClient instanceUnderTest = new DelegatingDockerClient(mockDelegate);
+
+        // When
+        final Object actualReturnValue = dockerClientMethod.invoke(instanceUnderTest, mockParameters);
+
+        // Then
+        if (mockReturnValue != null) {
+            assertThat("Returned value is what delegate returned", actualReturnValue, sameInstance(mockReturnValue));
+        }
+        dockerClientMethod.invoke(verify(mockDelegate, times(1)), mockParameters);
+        verifyNoMoreInteractions(mockDelegate);
+    }
+
+    private static Object[] createFakeArgumentValues(final Parameter[] methodParameters) throws Exception {
+        final Object[] mockParameters = new Object[methodParameters.length];
+        for (int i = 0; i < methodParameters.length; i++) {
+            final Class<?> paramType = methodParameters[i].getType();
+            final String paramName = "arg" + i;
+            mockParameters[i] = createFakeObject(paramType, paramName);
+        }
+        return mockParameters;
+    }
+
+    private static Object createFakeObject(final Class<?> paramType, final String paramName) throws Exception {
+        if (paramType.isEnum()) {
+            final Object[] values = (Object[]) paramType.getMethod("values").invoke(null);
+            return values[values.length / 2]; // pick a value in the middle
+        }
+        try {
+            return mock(paramType, paramName);
+        } catch (MockitoException ex) {
+            // Many arguments are of final classes that mockito can't mock, causing this
+            // exception.
+            // In such cases we just have to hope there's a constructor we
+            // can access and make a real instance instead of a mock.
+            // MAINTENANCE NOTE:
+            // So far we've gotten away with only looking for a default constructor.
+            // If, in future, this isn't enough then we could try picking another
+            // constructor and trying to fake any arguments it needs.
+            final Constructor<?> defaultConstructor = paramType.getConstructor();
+            return defaultConstructor.newInstance();
+        }
+    }
+}


### PR DESCRIPTION
Add a new class called "DelegatingDockerClient" which allows other plugins to easily "wrap" a DockerClient without also needing to stay tightly-coupled with a specific version of this plugin.

# The problem:
This plugin controls which version of docker-java we have; the version of docker-java controls what methods etc the DockerClient interface has.
However, any other plugins (e.g. the docker-plugin) that need to extend/wrap/override DockerClient do _not_ control what version of DockerClient they get, so while they have a compilation dependency on the exact version of docker-java that this plugin provides, they'll break if it changes.
This means that any change to this plugin has to be tightly coupled to matching changes in other plugins that use it, e.g. docker-plugin.

# The solution:
Adding this class (which was originally coded in the docker-plugin) into this plugin means that the docker-plugin doesn't need to change its code every single time this plugin is updated; the bit of code that has to stay "in lock step" with docker-java will be in the plugin that controls it, so any time this plugin changes the version of docker-java, it can also change the code to match the new DockerClient interface.
This should then mean that upgrading this plugin won't "break the world" anymore.

**TL;DR:** This puts some docker-java specific code (that needs to be kept "in step" with this plugin's docker-java) into the place that controls docker-java, protecting everyone else from changes.