### PR TITLE
Update docker-java to 3.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>docker-java-api</artifactId>
-    <version>${revision}.3-${changelist}</version>
+    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Docker API Plugin</name>
@@ -24,12 +24,12 @@
     </scm>
 
     <properties>
-        <revision>3.1.5</revision>
+        <revision>3.2.13</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>1.609.1</jenkins.version>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hpi.compatibleSinceVersion>3.1</hpi.compatibleSinceVersion>
+        <hpi.compatibleSinceVersion>3.2</hpi.compatibleSinceVersion>
     </properties>
 
     <licenses>
@@ -64,6 +64,10 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
                     <artifactId>jackson-jaxrs-json-provider</artifactId>
                 </exclusion>
@@ -86,6 +90,14 @@
                 <exclusion>
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
 
                 <!-- disable JAX-RS transport, otherwise, it requires shading and messy stuff -->

--- a/src/main/java/io/jenkins/dockerjavaapi/client/DelegatingDockerClient.java
+++ b/src/main/java/io/jenkins/dockerjavaapi/client/DelegatingDockerClient.java
@@ -478,4 +478,59 @@ public class DelegatingDockerClient implements DockerClient {
     public PruneCmd pruneCmd(PruneType pruneType) {
         return interceptAnswer(getDelegate().pruneCmd(pruneType));
     }
+
+    @Override
+    public RemoveConfigCmd removeConfigCmd(String configId) {
+        return interceptAnswer(getDelegate().removeConfigCmd(configId));
+    }
+
+    @Override
+    public InspectConfigCmd inspectConfigCmd(String configId) {
+        return interceptAnswer(getDelegate().inspectConfigCmd(configId));
+    }
+
+    @Override
+    public CreateConfigCmd createConfigCmd() {
+        return interceptAnswer(getDelegate().createConfigCmd());
+    }
+
+    @Override
+    public ListConfigsCmd listConfigsCmd() {
+        return interceptAnswer(getDelegate().listConfigsCmd());
+    }
+
+    @Override
+    public RemoveSecretCmd removeSecretCmd(String secretId) {
+        return interceptAnswer(getDelegate().removeSecretCmd(secretId));
+    }
+
+    @Override
+    public CreateSecretCmd createSecretCmd(SecretSpec secretSpec) {
+        return interceptAnswer(getDelegate().createSecretCmd(secretSpec));
+    }
+
+    @Override
+    public ListSecretsCmd listSecretsCmd() {
+        return interceptAnswer(getDelegate().listSecretsCmd());
+    }
+
+    @Override
+    public RemoveSwarmNodeCmd removeSwarmNodeCmd(String swarmNodeId) {
+        return interceptAnswer(getDelegate().removeSwarmNodeCmd(swarmNodeId));
+    }
+
+    @Override
+    public ResizeContainerCmd resizeContainerCmd(String containerId) {
+        return interceptAnswer(getDelegate().resizeContainerCmd(containerId));
+    }
+
+    @Override
+    public SaveImagesCmd saveImagesCmd() {
+        return interceptAnswer(getDelegate().saveImagesCmd());
+    }
+
+    @Override
+    public ResizeExecCmd resizeExecCmd(String execId) {
+        return interceptAnswer(getDelegate().resizeExecCmd(execId));
+    }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This is a proposal to partially replace #8 (ping @dnwe @SauceMcFloss : let me know what you think about this)

* Update docker-java to 3.2.13
* Set `hpi.compatibleSinceVersion=3.2`, making this version incompatible with older plugins depending on 3.1.x
* Use transitive dependencies exclusions instead of dependency management overrides
* Don't use BOM (yet)
* Don't update Jenkins (yet)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
