### PR TITLE
Add transport layer for Apache HttpClient5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-transport-httpclient5</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
             <version>2.10.3</version>


### PR DESCRIPTION
Link to [jenkinsci/docker-plugin#900](https://github.com/jenkinsci/docker-plugin/pull/900)

Add apache httpclient transport layer as dependency + update Guava dependency and force the scope internal to this plugin.
This plugin need to provide a transport layer available in docker-java like described [here ](https://github.com/docker-java/docker-java/blob/master/docs/transports.md).

I purpose apache httpclient wich is working well (tested since more than a year in docker-plugin on ours Jenkins env).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue