### PR TITLE
Use standard format for SCM URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <url>https://github.com/jenkinsci/docker-java-api-plugin</url>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/docker-java-api-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/docker-java-api-plugin.git</developerConnection>
+        <connection>scm:git:https://github.com/jenkinsci/docker-java-api-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/docker-java-api-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/docker-java-api-plugin</url>
         <tag>${scmTag}</tag>
     </scm>


### PR DESCRIPTION
This PR updates the SCM URLs to use the standard format used in other Jenkins plugins and the archetype. This format is less likely to cause problems for Plugin Compatibility Tester (PCT) and Maven Release Plugin (MRP).