### PR TITLE
Drop Netty transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This plugin exposes the [docker-java](http://github.com/docker-java/docker-java) API to Jenkins plugins.
 Plugins using docker-java should depend on this plugin and not directly on docker-java.
 
-Only Apache HttpClient 5 and Netty based transports are available; the Jersey transport does not work.
+Only the Apache HttpClient 5 transport is available; the Jersey transport does not work.
 
 # Environment
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>${revision}-${changelist}</version>
   <packaging>hpi</packaging>
   <name>Docker API Plugin</name>
-  <description>Plugin providing Docker API for other plugins. Wrap docker-java and required dependency for Netty transport only. JAX-RS default transport is not usable</description>
+  <description>Plugin providing Docker API for other plugins. Wrap docker-java and required dependency for Apache HttpClient 5 transport only. JAX-RS default transport is not usable</description>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>
@@ -70,10 +70,14 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
-        <!-- Deprecated transport -->
+        <!-- Deprecated transports -->
         <exclusion>
           <groupId>com.github.docker-java</groupId>
           <artifactId>docker-java-transport-jersey</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.github.docker-java</groupId>
+          <artifactId>docker-java-transport-netty</artifactId>
         </exclusion>
         <!-- Provided by Jenkins core -->
         <exclusion>


### PR DESCRIPTION
The Netty-based transport adds significant weight to the JAR and complexity to the linker, and as of https://github.com/jenkinsci/docker-build-step-plugin/pull/86 it won't be used anywhere except https://github.com/jenkinsci/nodepool-agents-plugin/blob/db1ddd9438516b676ef3accbd97df0ee1a875879/src/test/java/com/rackspace/jenkins_nodepool/NodePoolRule.java#L41 (which only has 40 installations).